### PR TITLE
Add basic WebSocket networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm run dev
 ```
 Open your browser at **http://localhost:5173**. Vite will live-reload JS and SCSS as you edit.
 
+### Start the WebSocket Server
+```bash
+npm run server
+```
+This syncs lobby state between all connected browsers via `ws://localhost:3000`.
+
 ### One-Click Offline Demo
 If you only need a fast demo with no build tools, simply double-click `index.html`. Most features work, but HMR and Sass compiling are disabled.
 

--- a/index.html
+++ b/index.html
@@ -268,6 +268,7 @@
 
     <!-- Load modular JavaScript files in dependency order -->
     <script src="js/room-state.js"></script>
+    <script src="js/network.js"></script>
     <script src="js/globals.js"></script>
     <script src="js/particles.js"></script>
     <script src="js/explosions.js"></script>

--- a/js/network.js
+++ b/js/network.js
@@ -1,0 +1,32 @@
+(function () {
+  if (typeof WebSocket === 'undefined' || typeof RoomState === 'undefined') {
+    return;
+  }
+
+  const ws = new WebSocket('ws://localhost:3000');
+  let applyingRemote = false;
+
+  ws.addEventListener('open', () => {
+    ws.send(JSON.stringify({ type: 'state', state: RoomState.getState() }));
+  });
+
+  ws.addEventListener('message', (ev) => {
+    let data;
+    try {
+      data = JSON.parse(ev.data);
+    } catch (err) {
+      return;
+    }
+    if (data.type === 'state') {
+      applyingRemote = true;
+      RoomState.replaceState(data.state || {});
+      applyingRemote = false;
+    }
+  });
+
+  RoomState.subscribe(() => {
+    if (ws.readyState === WebSocket.OPEN && !applyingRemote) {
+      ws.send(JSON.stringify({ type: 'state', state: RoomState.getState() }));
+    }
+  });
+})();

--- a/js/room-state.js
+++ b/js/room-state.js
@@ -196,6 +196,17 @@
             _notify('sandbox_updated');
         },
 
+        /** Replaces entire state from network snapshot */
+        replaceState(newState = {}) {
+            _state.players = Array.isArray(newState.players)
+                ? newState.players.map(p => ({ ...p }))
+                : [];
+            _state.mode = newState.mode || 'custom';
+            _state.settings = Object.assign({}, _state.settings, newState.settings);
+            _state.sandbox = Object.assign({}, _state.sandbox, newState.sandbox);
+            _notify('state_synced');
+        },
+
         /* ===== Convenience helpers ===== */
         get players() {
             return RoomState.getState().players;
@@ -212,4 +223,7 @@
 
     // Expose globally
     global.RoomState = RoomState;
-})(window); 
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = RoomState;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "localboofio-main",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "ws": "^8.15.1"
+      },
       "devDependencies": {
         "@playwright/test": "^1.43.1",
         "@testing-library/dom": "^9.3.1",
@@ -5321,7 +5324,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:e2e": "playwright test --reporter=line",
     "dev": "vite",
     "build": "vite build",
-    "start": "vite"
+    "start": "vite",
+    "server": "node server.js"
   },
   "keywords": [],
   "author": "",
@@ -23,5 +24,8 @@
     "@testing-library/jest-dom": "^6.2.0",
     "jsdom": "^24.0.0",
     "@playwright/test": "^1.43.1"
+  },
+  "dependencies": {
+    "ws": "^8.15.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,37 @@
+const http = require('http');
+const WebSocket = require('ws');
+const RoomState = require('./js/room-state.js');
+
+const server = http.createServer();
+const wss = new WebSocket.Server({ server });
+
+function broadcastState() {
+  const snapshot = RoomState.getState();
+  const msg = JSON.stringify({ type: 'state', state: snapshot });
+  wss.clients.forEach(client => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(msg);
+    }
+  });
+}
+
+wss.on('connection', ws => {
+  ws.send(JSON.stringify({ type: 'state', state: RoomState.getState() }));
+
+  ws.on('message', message => {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch (err) {
+      return;
+    }
+    if (data.type === 'state') {
+      RoomState.replaceState(data.state || {});
+      broadcastState();
+    }
+  });
+});
+
+server.listen(3000, () => {
+  console.log('WebSocket server listening on port 3000');
+});


### PR DESCRIPTION
## Summary
- add `server.js` with a tiny WebSocket server using `ws`
- add `js/network.js` to sync RoomState between clients and server
- expose `RoomState` for Node usage and add `replaceState` helper
- load the network layer in `index.html`
- update package files and README for running the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b58838c60832693eced5e3cc6a3b1