### PR TITLE
Add basic server room matchmaking

### DIFF
--- a/js/network.js
+++ b/js/network.js
@@ -6,21 +6,61 @@
         return;
     }
 
-    const socket = global.io();
+    const socket = global.io({ autoConnect: true });
+    let currentRoom = null;
+    let lastPing = 0;
 
     function emitUpdate(event, state) {
-        socket.emit('room:update', { event, state });
+        if (!currentRoom) return;
+        socket.emit('state:update', { event, state, roomId: currentRoom });
     }
 
-    socket.on('room:update', (payload) => {
+    function joinQuickplay() {
+        socket.emit('quickplay:join');
+    }
+
+    function joinRoom(roomId) {
+        currentRoom = roomId;
+        socket.emit('room:join', roomId);
+    }
+
+    function reconnect() {
+        if (currentRoom) {
+            socket.connect();
+            socket.emit('room:join', currentRoom);
+        }
+    }
+
+    socket.on('room:joined', ({ roomId }) => {
+        currentRoom = roomId;
+    });
+
+    socket.on('player:left', () => {
+        // future: handle removal from local state
+    });
+
+    socket.on('state:update', (payload) => {
         const RoomState = global.RoomState;
         if (!RoomState || typeof RoomState._applyState !== 'function') return;
         RoomState._applyState(payload.state);
+    });
+
+    socket.on('pong', () => {
+        const latency = Date.now() - lastPing;
+        global.Network.latency = latency;
     });
 
     if (global.RoomState && global.RoomState.subscribe) {
         global.RoomState.subscribe(emitUpdate);
     }
 
-    global.Network = { socket };
+    // simple heartbeat to measure latency
+    setInterval(() => {
+        if (socket.connected) {
+            lastPing = Date.now();
+            socket.emit('ping');
+        }
+    }, 2000);
+
+    global.Network = { socket, joinQuickplay, joinRoom, reconnect };
 })(window);

--- a/server.js
+++ b/server.js
@@ -10,10 +10,59 @@ const PORT = process.env.PORT || 3000;
 
 app.use(express.static(path.join(__dirname)));
 
+// --- Simple in-memory room/queue management ---
+const rooms = {};
+let quickQueue = [];
+
+function createRoom() {
+  return Math.random().toString(36).slice(2, 8);
+}
+
 io.on('connection', (socket) => {
+  let joinedRoom = null;
   console.log('client connected');
-  socket.on('room:update', (data) => {
-    socket.broadcast.emit('room:update', data);
+
+  socket.on('quickplay:join', () => {
+    quickQueue.push(socket);
+    if (quickQueue.length >= 2) {
+      const roomId = createRoom();
+      rooms[roomId] = { players: [] };
+      const players = quickQueue.splice(0, 2);
+      players.forEach((s) => {
+        s.join(roomId);
+        rooms[roomId].players.push(s.id);
+        s.emit('room:joined', { roomId });
+      });
+    }
+  });
+
+  socket.on('room:join', (roomId) => {
+    if (!rooms[roomId]) rooms[roomId] = { players: [] };
+    joinedRoom = roomId;
+    socket.join(roomId);
+    rooms[roomId].players.push(socket.id);
+    socket.emit('room:joined', { roomId });
+    socket.to(roomId).emit('player:joined', { id: socket.id });
+  });
+
+  socket.on('state:update', (payload) => {
+    if (!joinedRoom) return;
+    socket.to(joinedRoom).emit('state:update', payload);
+  });
+
+  socket.on('disconnect', () => {
+    if (joinedRoom && rooms[joinedRoom]) {
+      rooms[joinedRoom].players = rooms[joinedRoom].players.filter(
+        (id) => id !== socket.id
+      );
+      socket.to(joinedRoom).emit('player:left', { id: socket.id });
+      if (rooms[joinedRoom].players.length === 0) {
+        delete rooms[joinedRoom];
+      }
+    } else {
+      // remove from quick queue if pending
+      quickQueue = quickQueue.filter((s) => s !== socket);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add simple quickplay matchmaking and room management on server
- expose joinQuickplay, joinRoom, reconnect and latency ping in network layer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b70cdaddc83268a7520a5f1f0677c